### PR TITLE
Try to fix missing symbol on alternative architectures

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "grpc_java_plugin" %}
 {% set version = "1.46.0" %}
 {% set bazel_version = "4.2.1" %}
+{% set version_major_minor = ".".join(version.split(".")[:2]) %}
 
 package:
   name: {{ name|lower }}
@@ -22,7 +23,7 @@ source:
     fn: bazel  # [build_platform == "linux-64"]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:
@@ -33,8 +34,15 @@ requirements:
     - bazel-toolchain
     - libprotobuf
     - sed  # [osx]
+    # 2021/12/14 hmaarrfk
+    # I'm not sure if this is needed here but I want
+    # to make a build to make sure the symbols get found.
+    - grpc-cpp  {{ version_major_minor }}
   host:
     - libprotobuf
+    # grpc is needed to generate the appropriate stubs since version 1.40.1
+    # https://github.com/grpc/grpc-java/issues/8523#issuecomment-918689308
+    - grpc-cpp  {{ version_major_minor }}
 
 test:
   commands:


### PR DESCRIPTION
@conda-forge-admin please rerender
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
