### PR TITLE
back to 1.55.1, backport patch for string_view-compat

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.73.0" %}
+{% set version = "1.55.1" %}
 
 # bazel 7+ requires setting up a toolchain so that the macOS SDK in a non-standard
 # location is accepted, which would require bazel-toolchain etc.
@@ -11,11 +11,14 @@ package:
 
 source:
   - url: https://github.com/grpc/grpc-java/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: eca44a9f3eb341daf7a01482b96016dfa7d91baee495a697746c4724868a06db
+    sha256: be779db38a72a0c693706c433133189538b04979eba1b728eaa21f4fd0f967d8
     patches:
       - patches/0001-Build-against-system-libprotobuf.patch
       - patches/0002-use-C-17.patch
       - patches/0003-Add-abseil-libs-for-newer-protobuf-versions.patch
+      # backport https://github.com/grpc/grpc-java/commit/f299ef5e5832898fa29ede31dee1a6085b90c051
+      # from compatibility with absl::string_view being equal to std::string_view
+      - patches/0004-compiler-Prepare-for-C-protobuf-using-string_view.patch
 
   - fn: bazel
     url: {{ bz_base_url }}/{{ bz_version }}/bazel_nojdk-{{ bz_version }}-linux-x86_64   # [build_platform == "linux-64"]
@@ -24,7 +27,7 @@ source:
     sha256: ccc67fa48a6444818a5b85e8174c89ca2630df60c1e2327714d944035a240fc9            # [build_platform == "osx-64"]
 
 build:
-  number: 0
+  number: 14
   skip: true  # [win]
 
 requirements:

--- a/recipe/patches/0001-Build-against-system-libprotobuf.patch
+++ b/recipe/patches/0001-Build-against-system-libprotobuf.patch
@@ -1,7 +1,7 @@
-From 28a6934bd50c81e8307c9a9146f9f31bd66f303c Mon Sep 17 00:00:00 2001
+From d2d1b8efcab74f99bd3f79da8e1cc0a91861aca7 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwelk@xhochy.com>
 Date: Sun, 21 Mar 2021 20:11:25 +0100
-Subject: [PATCH 1/3] Build against system libprotobuf
+Subject: [PATCH 1/4] Build against system libprotobuf
 
 ---
  WORKSPACE            |   4 +-
@@ -18,10 +18,10 @@ Subject: [PATCH 1/3] Build against system libprotobuf
  create mode 100644 protobuf_deps.bzl
 
 diff --git a/WORKSPACE b/WORKSPACE
-index 7bbfbcc5f..02f1aead1 100644
+index 4727a9621..8fd4921fa 100644
 --- a/WORKSPACE
 +++ b/WORKSPACE
-@@ -22,8 +22,10 @@ load("//:repositories.bzl", "grpc_java_repositories")
+@@ -16,8 +16,10 @@ load("//:repositories.bzl", "grpc_java_repositories")
  
  grpc_java_repositories()
  
@@ -34,10 +34,10 @@ index 7bbfbcc5f..02f1aead1 100644
  protobuf_deps()
  
 diff --git a/compiler/BUILD.bazel b/compiler/BUILD.bazel
-index 753f48507..c9a999251 100644
+index f88075c0e..3aa9f1030 100644
 --- a/compiler/BUILD.bazel
 +++ b/compiler/BUILD.bazel
-@@ -13,6 +13,7 @@ cc_binary(
+@@ -12,6 +12,7 @@ cc_binary(
      visibility = ["//visibility:public"],
      deps = [
          "@com_google_protobuf//:protoc_lib",
@@ -741,22 +741,22 @@ index 000000000..155a02e1b
 +            urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
 +        )
 diff --git a/repositories.bzl b/repositories.bzl
-index d55ff07e7..fbeb27165 100644
+index 2e3b2b62c..54a6ca35d 100644
 --- a/repositories.bzl
 +++ b/repositories.bzl
-@@ -153,11 +153,11 @@ def com_google_protobuf():
+@@ -148,11 +148,11 @@ def com_google_protobuf():
      # proto_library rules implicitly depend on @com_google_protobuf//:protoc,
      # which is the proto-compiler.
      # This statement defines the @com_google_protobuf repo.
 -    http_archive(
 +    native.new_local_repository(
          name = "com_google_protobuf",
--        sha256 = "9bd87b8280ef720d3240514f884e56a712f2218f0d693b48050c836028940a42",
--        strip_prefix = "protobuf-25.1",
--        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protobuf-25.1.tar.gz"],
+-        sha256 = "5d0f05587aa3ad56079b4c4481dcb462267e5f1075d905c321f8ed6339e74ab0",
+-        strip_prefix = "protobuf-22.3",
+-        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protobuf-22.3.zip"],
 +        path = ".",
 +        build_file = "./protobuf.BUILD",
 +        workspace_file = "./protobuf.WORKSPACE"
      )
  
- def io_grpc_grpc_proto():
+ def com_google_protobuf_javalite():

--- a/recipe/patches/0002-use-C-17.patch
+++ b/recipe/patches/0002-use-C-17.patch
@@ -1,7 +1,7 @@
-From 18615f5721b62143f821566005bea82e309ac32a Mon Sep 17 00:00:00 2001
+From a68a0fbdff902ac09077fc522aa19a0667b9ac6d Mon Sep 17 00:00:00 2001
 From: "H. Vetinari" <h.vetinari@gmx.com>
 Date: Wed, 24 May 2023 22:06:05 +1100
-Subject: [PATCH 2/3] use C++17
+Subject: [PATCH 2/4] use C++17
 
 ---
  .bazelrc | 2 +-

--- a/recipe/patches/0003-Add-abseil-libs-for-newer-protobuf-versions.patch
+++ b/recipe/patches/0003-Add-abseil-libs-for-newer-protobuf-versions.patch
@@ -1,7 +1,7 @@
-From 21eb33bdcfc636797782f87241ef737a16dbd029 Mon Sep 17 00:00:00 2001
+From 939572f6fe4fc4b11b91ef30f40c4ef3dd369733 Mon Sep 17 00:00:00 2001
 From: "Uwe L. Korn" <uwe.korn@quantco.com>
 Date: Tue, 13 Jun 2023 16:52:25 +0200
-Subject: [PATCH 3/3] Add abseil libs for newer protobuf versions
+Subject: [PATCH 3/4] Add abseil libs for newer protobuf versions
 
 ---
  protobuf.BUILD | 6 +++---

--- a/recipe/patches/0004-compiler-Prepare-for-C-protobuf-using-string_view.patch
+++ b/recipe/patches/0004-compiler-Prepare-for-C-protobuf-using-string_view.patch
@@ -1,0 +1,126 @@
+From df0b4c114282c90ed76ae7ede36036a31a284ed4 Mon Sep 17 00:00:00 2001
+From: Eric Anderson <ejona@google.com>
+Date: Wed, 15 Jan 2025 14:51:45 -0800
+Subject: [PATCH 4/4] compiler: Prepare for C++ protobuf using string_view
+
+Protobuf is interested in using absl::string_view instead of const
+std::string&. Just copy to std::string as the C++17 build isn't yet
+operational and that level of performance doesn't matter.
+
+cl/711732759 b/353571051
+---
+ .../src/java_plugin/cpp/java_generator.cpp    | 33 ++++++++++---------
+ 1 file changed, 17 insertions(+), 16 deletions(-)
+
+diff --git a/compiler/src/java_plugin/cpp/java_generator.cpp b/compiler/src/java_plugin/cpp/java_generator.cpp
+index 51e86d9ce..06297d576 100644
+--- a/compiler/src/java_plugin/cpp/java_generator.cpp
++++ b/compiler/src/java_plugin/cpp/java_generator.cpp
+@@ -147,7 +147,7 @@ static std::set<std::string> java_keywords = {
+ //   - decapitalize the first letter
+ //   - remove embedded underscores & capitalize the following letter
+ //  Finally, if the result is a reserved java keyword, append an underscore.
+-static std::string MixedLower(const std::string& word) {
++static std::string MixedLower(std::string word) {
+   std::string w;
+   w += tolower(word[0]);
+   bool after_underscore = false;
+@@ -169,7 +169,7 @@ static std::string MixedLower(const std::string& word) {
+ //   - An underscore is inserted where a lower case letter is followed by an
+ //     upper case letter.
+ //   - All letters are converted to upper case
+-static std::string ToAllUpperCase(const std::string& word) {
++static std::string ToAllUpperCase(std::string word) {
+   std::string w;
+   for (size_t i = 0; i < word.length(); ++i) {
+     w += toupper(word[i]);
+@@ -181,19 +181,19 @@ static std::string ToAllUpperCase(const std::string& word) {
+ }
+ 
+ static inline std::string LowerMethodName(const MethodDescriptor* method) {
+-  return MixedLower(method->name());
++  return MixedLower(std::string(method->name()));
+ }
+ 
+ static inline std::string MethodPropertiesFieldName(const MethodDescriptor* method) {
+-  return "METHOD_" + ToAllUpperCase(method->name());
++  return "METHOD_" + ToAllUpperCase(std::string(method->name()));
+ }
+ 
+ static inline std::string MethodPropertiesGetterName(const MethodDescriptor* method) {
+-  return MixedLower("get_" + method->name() + "_method");
++  return MixedLower("get_" + std::string(method->name()) + "_method");
+ }
+ 
+ static inline std::string MethodIdFieldName(const MethodDescriptor* method) {
+-  return "METHODID_" + ToAllUpperCase(method->name());
++  return "METHODID_" + ToAllUpperCase(std::string(method->name()));
+ }
+ 
+ static inline std::string MessageFullJavaName(const Descriptor* desc) {
+@@ -404,7 +404,7 @@ static void GrpcWriteServiceDocComment(Printer* printer,
+                                        StubType type) {
+   printer->Print("/**\n");
+ 
+-  std::map<std::string, std::string> vars = {{"service", service->name()}};
++  std::map<std::string, std::string> vars = {{"service", std::string(service->name())}};
+   switch (type) {
+     case ASYNC_CLIENT_IMPL:
+       printer->Print(vars, " * A stub to allow clients to do asynchronous rpc calls to service $service$.\n");
+@@ -515,7 +515,8 @@ static void PrintMethodFields(
+         "            .setResponseMarshaller($ProtoUtils$.marshaller(\n"
+         "                $output_type$.getDefaultInstance()))\n");
+ 
+-    (*vars)["proto_method_descriptor_supplier"] = service->name() + "MethodDescriptorSupplier";
++    (*vars)["proto_method_descriptor_supplier"]
++        = std::string(service->name()) + "MethodDescriptorSupplier";
+     if (flavor == ProtoFlavor::NORMAL) {
+       p->Print(
+           *vars,
+@@ -575,7 +576,7 @@ static void PrintStub(
+     const ServiceDescriptor* service,
+     std::map<std::string, std::string>* vars,
+     Printer* p, StubType type) {
+-  const std::string service_name = service->name();
++  std::string service_name = std::string(service->name());
+   (*vars)["service_name"] = service_name;
+   std::string stub_name = service_name;
+   std::string stub_base_class_name = "AbstractStub";
+@@ -821,8 +822,7 @@ static void PrintAbstractClassStub(
+     const ServiceDescriptor* service,
+     std::map<std::string, std::string>* vars,
+     Printer* p) {
+-  const std::string service_name = service->name();
+-  (*vars)["service_name"] = service_name;
++  (*vars)["service_name"] = service->name();
+ 
+   GrpcWriteServiceDocComment(p, service, ABSTRACT_CLASS);
+   if (service->options().deprecated()) {
+@@ -956,13 +956,14 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
+                                    std::map<std::string, std::string>* vars,
+                                    Printer* p,
+                                    ProtoFlavor flavor) {
+-  (*vars)["service_name"] = service->name();
++  std::string service_name = std::string(service->name());
++  (*vars)["service_name"] = service_name;
+ 
+ 
+   if (flavor == ProtoFlavor::NORMAL) {
+-    (*vars)["proto_base_descriptor_supplier"] = service->name() + "BaseDescriptorSupplier";
+-    (*vars)["proto_file_descriptor_supplier"] = service->name() + "FileDescriptorSupplier";
+-    (*vars)["proto_method_descriptor_supplier"] = service->name() + "MethodDescriptorSupplier";
++    (*vars)["proto_base_descriptor_supplier"] = service_name + "BaseDescriptorSupplier";
++    (*vars)["proto_file_descriptor_supplier"] = service_name + "FileDescriptorSupplier";
++    (*vars)["proto_method_descriptor_supplier"] = service_name + "MethodDescriptorSupplier";
+     (*vars)["proto_class_name"] = protobuf::compiler::java::ClassName(service->file());
+     p->Print(
+         *vars,
+@@ -1283,7 +1284,7 @@ std::string ServiceJavaPackage(const FileDescriptor* file) {
+ }
+ 
+ std::string ServiceClassName(const ServiceDescriptor* service) {
+-  return service->name() + "Grpc";
++  return std::string(service->name()) + "Grpc";
+ }
+ 
+ }  // namespace java_grpc_generator


### PR DESCRIPTION
So the builds from #91 look like they're not usable in https://github.com/conda-forge/bazel-feedstock/pull/263; bazel 7.5 vendors a really old grpc-java v1.47, so pushing too far ahead there seems to get us into hot water. 

The version bump in #91 was mainly due to issues with C++17, and what that means for `absl::string_view`
```
compiler/src/java_plugin/cpp/java_generator.cpp:1286:26: error: no match for 'operator+' (operand types are 'absl::lts_20250512::string_view' {aka 'std::basic_string_view<char>'} and 'const char [5]')
 1286 |   return service->name() + "Grpc";
      |          ~~~~~~~~~~~~~~~ ^ ~~~~~~
      |                       |    |
      |                       |    const char [5]
      |                       absl::lts_20250512::string_view {aka std::basic_string_view<char>}
```

Since the commit (https://github.com/grpc/grpc-java/commit/f299ef5e5832898fa29ede31dee1a6085b90c051) that fixes this only landed in grpc-java v1.71 (still way too new in all likelihood), we need to backport this. Somewhat surprisingly, it applied cleanly to v1.55.1
