### PR TITLE
grpc_java_plugin v1.56.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.55.1" %}
+{% set version = "1.56.1" %}
 
 # bazel 7+ requires setting up a toolchain so that the macOS SDK in a non-standard
 # location is accepted, which would require bazel-toolchain etc.
@@ -11,7 +11,7 @@ package:
 
 source:
   - url: https://github.com/grpc/grpc-java/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: be779db38a72a0c693706c433133189538b04979eba1b728eaa21f4fd0f967d8
+    sha256: 17dd91014032a147c978ae99582fddd950f5444388eae700cf51eda0326ad2f9
     patches:
       - patches/0001-Build-against-system-libprotobuf.patch
       - patches/0002-use-C-17.patch
@@ -27,7 +27,7 @@ source:
     sha256: ccc67fa48a6444818a5b85e8174c89ca2630df60c1e2327714d944035a240fc9            # [build_platform == "osx-64"]
 
 build:
-  number: 14
+  number: 0
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
After #91 and #92, build out the versions in between so we have a proper history for branching off of, should we need to maintain any other versions going forward.

I'll do the rest without PRs though - takes too long, and it's not really _that_ crucial if any given version builds completely. We can always fix it later when we create a branch.