### PR TITLE
grpc_java_plugin v1.73.0 [take 2]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.72.0" %}
+{% set version = "1.73.0" %}
 
 # bazel 7+ requires setting up a toolchain so that the macOS SDK in a non-standard
 # location is accepted, which would require bazel-toolchain etc.
@@ -11,7 +11,7 @@ package:
 
 source:
   - url: https://github.com/grpc/grpc-java/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 524a3d687f06ffd1c6ab66dbbb5de5b9f6adaa662570aa56e553d86c2065eb31
+    sha256: eca44a9f3eb341daf7a01482b96016dfa7d91baee495a697746c4724868a06db
     patches:
       - patches/0001-Build-against-system-libprotobuf.patch
       - patches/0002-use-C-17.patch


### PR DESCRIPTION
This concludes the journey from #91, #92, #93 and all the intervening commits (luckily, all passing 🥳). The diff of this against aebefe7371e2553aaedb14463958ebbe9949cd59 is empty (aside from hashes in the patches), so I'm intentionally not bumping the build number.